### PR TITLE
Fix fusesoc to build the verilator model.

### DIFF
--- a/core-v-mcu.core
+++ b/core-v-mcu.core
@@ -147,12 +147,6 @@ filesets:
     - rtl/core-v-mcu/verilator.waiver
     file_type: vlt
 
-  # Verilator wrapper
-  verilator_wrapper:
-    files:
-    - rtl/core-v-mcu/top/core_v_mcu_wrapper.sv
-    file_type: systemVerilogSource
-
 parameters:
   PULP_FPGA_EMUL:
     datatype: bool
@@ -202,9 +196,8 @@ targets:
     default_tool: verilator
     filesets_append:
     - pre_build_scripts
-    - verilator_wrapper
     - verilator-waiver
-    toplevel: [core_v_mcu_wrapper]
+    toplevel: [core_v_mcu]
     hooks:
       pre_build: [pre_build_scripts]
     tools:


### PR DESCRIPTION
	With the new code base, there is no need for a wrapper for the
	Verilator model.

Files changed:

	* core-v-mcu.core: Remove declaration of the verilator_wrapper
	fileset and its reference in the model-lib target; make core_v_mcu
	the top level for the model-lib target.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>